### PR TITLE
Fix cpplint for projects with spaces in path

### DIFF
--- a/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
@@ -41,12 +41,14 @@ public class CpplintInspection extends LocalInspectionTool {
     // Don't pass project root
     String flag = "";
     if (!MinGWUtil.isMinGWEnvironment()) {
-      flag += "--root=" + projectRoot;
+      flag += "--root=\"" + projectRoot + "\"";
     }
     String cppFilePath = file.getVirtualFile().getCanonicalPath();
     if (CygwinUtil.isCygwinEnvironment()) {
       cppFilePath = CygwinUtil.toCygwinPath(cppFilePath);
     }
+    cppFilePath = "\"" + cppFilePath + "\"";
+
     Scanner scanner = null;
     try {
       String message = CpplintCommand.execute(file.getProject(), flag, cppFilePath);


### PR DESCRIPTION
Previously, cpplint would fail if the project path had spaces in it.
