### PR TITLE
Fix null exception in options

### DIFF
--- a/src/com/github/itechbear/clion/cpplint/CpplintCommand.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintCommand.java
@@ -28,6 +28,12 @@ public class CpplintCommand {
       return "";
     }
 
+    // First time users will not have this Option set if they do not open the Settings
+    // UI yet.
+    if (null == cpplintOptions) {
+      cpplintOptions = "";
+    }
+
     if (!MinGWUtil.isMinGWEnvironment()) {
       args.add(CygwinUtil.getBathPath());
       args.add("-c");


### PR DESCRIPTION
This PR fixes a null pointer exception that is thrown if the inspection is run on a file before the user has applied the Settings for the first time.
