### PR TITLE
Fix highlight coloring to properly match other errors in CLion

### DIFF
--- a/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
@@ -78,7 +78,7 @@ public class CpplintInspection extends LocalInspectionTool {
         lineNumber = (lineNumber > 0) ? (lineNumber - 1) : 0;
         String errorMessage = "cpplint: " + matcher.group(2);
         String ruleName = matcher.group(3);
-        int warning_level = Integer.parseInt(matcher.group(4), 10);
+        int confidence_score = Integer.parseInt(matcher.group(4), 10);
         int line_start_offset = document.getLineStartOffset(lineNumber);
         int line_end_offset = document.getLineEndOffset(lineNumber);
         LocalQuickFixBase fix = QuickFixesManager.get(ruleName);

--- a/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
@@ -82,7 +82,7 @@ public class CpplintInspection extends LocalInspectionTool {
         int line_start_offset = document.getLineStartOffset(lineNumber);
         int line_end_offset = document.getLineEndOffset(lineNumber);
         LocalQuickFixBase fix = QuickFixesManager.get(ruleName);
-        ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(file, TextRange.create(line_start_offset, line_end_offset), errorMessage, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, true, fix);
+        ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(file, TextRange.create(line_start_offset, line_end_offset), errorMessage, ProblemHighlightType.WEAK_WARNING, true, fix);
         descriptors.add(problemDescriptor);
       }
     } catch (IOException e) {


### PR DESCRIPTION
Switched the highlight type to `WEAK_WARNING` because `cpplint` is simply a style checker, not a coding problem error.  `WEAK_WARNING` is more consistent with CLion/IntelliJ style inspections.
