### PR TITLE
Fix cpplint working directory and --root option

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -13,6 +13,8 @@
         Run cpplint.py on the fly when you are editing C++ source code.<br/>
         Highlight corresponding lines with messages about which cpplint.py complains.<br/>
         Cygwin/MinGW environment is supported as well.<br/><br/>
+        For advanced cpplint features, such as setting project repository root for header guard checks, use the PyPI
+        hosted cpplint at https://pypi.python.org/pypi/cpplint.<br/>
 
       <b>Usage:</b><br/>
         Install this plugin.<br/>

--- a/src/com/github/itechbear/clion/cpplint/CpplintCommand.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintCommand.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.StatusBar;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -49,8 +50,9 @@ public class CpplintCommand {
       Collections.addAll(args, arg);
     }
 
+    File cpplintWorkingDirectory = new File(project.getBaseDir().getCanonicalPath());
     final Process process = Runtime.getRuntime().exec(
-        args.toArray(new String[args.size()]));
+        args.toArray(new String[args.size()]), null, cpplintWorkingDirectory);
 
     final StringBuilder outString = new StringBuilder();
     Thread outThread = new Thread(new Runnable() {

--- a/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
+++ b/src/com/github/itechbear/clion/cpplint/CpplintInspection.java
@@ -2,7 +2,6 @@ package com.github.itechbear.clion.cpplint;
 
 import com.github.itechbear.clion.cpplint.QuickFixes.QuickFixesManager;
 import com.github.itechbear.util.CygwinUtil;
-import com.github.itechbear.util.MinGWUtil;
 import com.intellij.codeInspection.*;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -32,17 +31,6 @@ public class CpplintInspection extends LocalInspectionTool {
       return descriptors.toArray(new ProblemDescriptor[descriptors.size()]);
     }
 
-    // Format the path of the project root. Otherwise, cpplint would keep reporting header guard errors.
-    String projectRoot = file.getProject().getBaseDir().getCanonicalPath();
-    if (CygwinUtil.isCygwinEnvironment()) {
-      projectRoot = CygwinUtil.toCygwinPath(projectRoot);
-    }
-
-    // Don't pass project root
-    String flag = "";
-    if (!MinGWUtil.isMinGWEnvironment()) {
-      flag += "--root=\"" + projectRoot + "\"";
-    }
     String cppFilePath = file.getVirtualFile().getCanonicalPath();
     if (CygwinUtil.isCygwinEnvironment()) {
       cppFilePath = CygwinUtil.toCygwinPath(cppFilePath);
@@ -51,7 +39,7 @@ public class CpplintInspection extends LocalInspectionTool {
 
     Scanner scanner = null;
     try {
-      String message = CpplintCommand.execute(file.getProject(), flag, cppFilePath);
+      String message = CpplintCommand.execute(file.getProject(), cppFilePath);
       if (message.isEmpty()) {
         return descriptors.toArray(new ProblemDescriptor[descriptors.size()]);
       }


### PR DESCRIPTION
This PR allows the user to properly set the header guard checks in `cpplint`.  `cpplint` relies on the current working directory to find the root of the version control repository, of which, `--root` is relative.

This PR sets the working directory for `cpplint` to the CLion project path (which is what would be expected).  Users can then use a combination of `--repository` and `--root` to customize exactly what the header guards should be.

`--root` is no longer hard coded into the call to `cpplint` so that the user can customize the call as they feel fit.  By default it will work as before, though, since the current working directory is what was set constantly before.

`--repository` is only available in the advanced features added to the PyPI fork of `cpplint` located here: https://pypi.python.org/pypi/cpplint, thus to help users, a link to it is added to the plugin help page. This allows a user to properly use `cpplint` even if their project is not currently in a version controlled project.
